### PR TITLE
Updates license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,7 @@
   "bugs": {
     "url": "https://github.com/teseve/teseve/issues"
   },
-  "licenses": [
-    {
-      "type": "UNLICENSE",
-      "url": "https://github.com/teseve/teseve/blob/master/LICENSE"
-    }
-  ],
+  "license": "Unlicense",
   "electron-version": "0.32.1",
   "dependencies": {
     "empty-port": "0.0.1",


### PR DESCRIPTION
As per https://docs.npmjs.com/files/package.json#license, "licenses" is deprecated, and "license" is the new way to store license information. This will get rid of this warning:

<img width="458" alt="screen shot 2015-10-30 at 7 10 46 pm" src="https://cloud.githubusercontent.com/assets/9198315/10860679/f8c58148-7f39-11e5-8170-f6f64e62fb6b.png">

Also changes "UNLICENSE" to "Unlicense" which is a valid SPDX license expression (http://spdx.org/licenses/Unlicense.html)
